### PR TITLE
chore: fix Authors@R ORCID field for CRAN + acknowledge modern alternatives

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,12 +1,12 @@
 Package: marsrad
 Title: Mars Solar Radiation
-Version: 1.0.0
+Version: 1.0.1
 Authors@R: 
     person(given = "Georges",
            family = "Labrèche",
            role = c("aut", "cre"),
            email = "georges@tanagraspace.com",
-           comment = structure("0000-0002-2104-8789", .Names = "ORCID"))
+           comment = c(ORCID = "0000-0002-2104-8789"))
 Description: A set of functions to calculate solar irradiance and insolation on Mars horizontal and inclined surfaces. Based on NASA Technical Memoranda 102299, 103623, 105216, 106321, and 106700, i.e. the canonical Mars solar radiation papers.
 License: GPL-3
 URL: https://georges.fyi/marsrad/, https://github.com/georgeslabreche/marsrad

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ For a complete list of all functions with descriptions, see [FUNCTIONS.md](https
 ## Parameters
 
 Calculate and plot solar radiation on Mars as a function of the following parameters:
+
 - Areocentric Longitude (Ls)
 - Planetary Latitude (phi)
 - Solar Time (omega)
@@ -61,6 +62,16 @@ Calculate and plot solar radiation on Mars as a function of the following parame
 - Albedo (al)
 - Slope Angle (beta)
 - Slope Orientation (gamma)
+
+## Old School Cool
+
+The Appelbaum formulas are based on Viking Lander optical depth measurements from the late 1970s and early 1980s. They're 36+ years old now and Mars science has moved on. More recent work includes:
+
+- [An improved model for available solar energy on Mars: Optimizing solar panel orientation to assess potential spacecraft landing sites](https://www.sciencedirect.com/science/article/abs/pii/S0273117723002673) (Kerr et al., 2023).
+- [A model to calculate solar radiation fluxes on the Martian surface](https://www.swsc-journal.org/articles/swsc/full_html/2015/01/swsc150027/swsc150027.html) (Vicente-Retortillo et al., 2015).
+- [Fast and accurate estimation of solar irradiance on Martian slopes](https://agupubs.onlinelibrary.wiley.com/doi/full/10.1029/2008GL034956) (Spiga et al., 2008).
+
+However, the Appelbaum formulas remain useful for first-order estimates, educational purposes, and quick trade studies. They're well-documented, easy to understand, analytically tractable, and give you reasonable ballpark figures for solar energy budgets on Mars. Just don't use them to design your actual flight hardware without consulting more recent atmospheric models.
 
 ## Getting Started
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,17 +1,17 @@
+## Resubmission
+
+This is a patch release (1.0.0 -> 1.0.1) addressing the NOTE flagged in
+the CRAN check results for marsrad 1.0.0:
+
+> Authors@R field gives a non-standard call: structure("0000-0002-2104-8789", .Names = "ORCID")
+
+The `Authors@R` field has been updated to use the CRAN-allowed
+`c(ORCID = "0000-0002-2104-8789")` form, which also resolves the
+downstream Author/Maintainer field mismatch reported on r-devel-debian.
+
 ## R CMD check results
 
-0 errors | 0 warnings | 2 notes
-
-* This is a new submission.
-
-* NOTE: checking CRAN incoming feasibility
-  - Maintainer: 'Georges Labrèche <georges@tanagraspace.com>'
-  - New submission
-  - This is expected for a first-time CRAN submission.
-
-* NOTE: checking top-level files
-  - Files 'README.md' or 'NEWS.md' cannot be checked without 'pandoc' being installed.
-  - This is a local environment limitation and does not affect package functionality.
+0 errors | 0 warnings | 0 notes
 
 ## Test environments
 


### PR DESCRIPTION
## Summary

- Fix the `Authors@R` ORCID comment in `DESCRIPTION`: replaces the non-standard `structure("0000-0002-2104-8789", .Names = "ORCID")` with the CRAN-allowed `c(ORCID = "0000-0002-2104-8789")`.
- Add an "Old School Cool" section to `README.md` acknowledging more contemporary Mars solar radiation models (Kerr et al. 2023, Vicente-Retortillo et al. 2015, Spiga et al. 2008).

## Why

CRAN check results for marsrad 1.0.0 ([check page](https://cran.r-project.org/web/checks/check_results_marsrad.html)) flag a NOTE on every release/devel platform:

> The Authors@R field contains a non-standard call: `structure("0000-0002-2104-8789", .Names = "ORCID")`. CRAN requires using only standard functions like `person()`, `as.person()`, `c()`, `list()`, `paste()`, or `paste0()`.

The Author/Maintainer field mismatch reported on r-devel-debian is a downstream consequence of the same parse failure — fixing the `Authors@R` resolves both. CRAN deadline for resolution: **2026-05-18**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)